### PR TITLE
refactor: replace link from 12rambau branch

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -69,7 +69,7 @@ install with pip:
 
 And you will be able to produce this type of Bloch sphere's tree: 
 
-.. image::  https://raw.githubusercontent.com/12rambau/qutree/pre-release/docs/source/_static/example.png
+.. image::  https://raw.githubusercontent.com/alice4space/qutree/main/docs/source/_static/example.png
     :alt: example tree
 
 More information can be found in our `documentation <https://pyqutree.readthedocs.io/en/latest/>`__. 


### PR DESCRIPTION
I cannot delete my `pre-release` branch yet as the image is still used in the readme